### PR TITLE
Add Dockerfile with non-root user security hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Git
+.git
+.gitignore
+
+# Build artifacts
+target/
+build/
+*.jar
+
+# Logs
+*.log
+
+# Environment files (except those needed)
+.env*
+
+# Maven wrapper
+mvnw*
+.mvn/wrapper/maven-wrapper.jar
+
+# Temporary files
+tmp/
+temp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+ARG APP_USER=appuser
+ARG APP_UID=10001  # Changed from 1000 to avoid conflicts with host users
+ARG APP_GID=10001
+
+RUN useradd \
+    --home "/app" \
+    --create-home \
+    --user-group \
+    --uid "$APPUID" \
+    "$APPUSER"
+
+
+RUN mkdir -p /app/logs /app/tmp && \
+    chown -R ${APP_USER}:${APP_USER} /app && \
+    chmod -R 755 /app
+
+WORKDIR /app
+USER appuser
+
+
+COPY ./ATTRIBUTION.md ./LICENSES.md
+COPY --chown=appuser:appuser --from=build-env /app.jar .
+
+
+RUN umask 0027
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
## Security Improvements:
1. **Non-root user**: Created 'appuser' with UID/GID 10001
2. **Least privilege**: Container runs as non-root user
3. **High UID**: Avoids conflicts with host system users

Resolves: #3