### PR TITLE
feat: generate public and private subnets dynamically for VPC

### DIFF
--- a/terraform-manifests/modules/vpc/datasources-and-locals.tf
+++ b/terraform-manifests/modules/vpc/datasources-and-locals.tf
@@ -1,0 +1,11 @@
+# Datasources
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# Locals Block
+locals {
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  public_subnets  = [for k, az in local.azs : cidrsubnet(var.vpc_cidr, var.subnet_newbits, k)]
+  private_subnets = [for k, az in local.azs : cidrsubnet(var.vpc_cidr, var.subnet_newbits, k + 10)]
+}


### PR DESCRIPTION
Closes #16 

This PR updates the locals block to dynamically generate public and private subnets for the VPC.