### PR TITLE
VPC outputs for IDs and subnet mappings

### DIFF
--- a/f
+++ b/f
@@ -1,0 +1,12 @@
+  feat/001-add-dockerignore[m
+  feat/003-non-root-user[m
+  feat/004-layer-caching[m
+* [32mfeat/add-vpc-outputs[m
+  feat/create-vpc-infrastructure[m
+  feat/datasources-locals-vpc-network-calculations[m
+  feat/kubernetes-01-basic-pod[m
+  feat/kubernetes-01-catalog-pod[m
+  feat/kubernetes-resource-limits[m
+  feat/terraform-s3-backend-issue[m
+  feat/terraform-vpc-setup[m
+  main[m

--- a/terraform-manifests/output.tf
+++ b/terraform-manifests/output.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  value       = module.vpc.vpc_id
+  description = "VPC ID used by EKS and other services"
+}
+
+output "private_subnet_ids" {
+  value       = module.vpc.private_subnet_ids
+  description = "Private subnets for EKS worker nodes"
+}
+
+output "public_subnet_ids" {
+  value       = module.vpc.public_subnet_ids
+  description = "Public subnets for ALB, NLB, etc."
+}
+
+output "public_subnet_map" {
+  value       = module.vpc.public_subnet_map
+  description = "Public subnets for ALB, NLB, etc."
+}


### PR DESCRIPTION
This PR adds outputs for the VPC Terraform module to make it easier to reference resources in other modules or automation.
