### PR TITLE
feat: restructure Terraform to modules/ + envs/ pattern Ref: #26

### DIFF
--- a/envs/au-prod/README.md
+++ b/envs/au-prod/README.md
@@ -1,0 +1,19 @@
+# au-prod — Production Environment
+
+**Status:** Placeholder — not yet deployed  
+**Region:** ap-southeast-2 (Sydney)  
+**VPC CIDR:** 10.0.0.0/16  
+
+## How to Create
+
+1. Copy all `.tf` files from `envs/au-dev/`
+2. Update `terraform.tfvars` with prod values (see Dev vs Prod table in requirements doc)
+3. Update `c1-versions.tf` backend to `ausmart-terraform-state-prod`
+4. Key changes from dev:
+   - `enable_kms = true`
+   - `enable_waf = true`
+   - `enable_vpc_endpoints = true`
+   - `enable_multi_az = true`
+   - `single_nat_gateway = false`
+   - `rds_deletion_protection = true`
+   - `public_access_cidrs = ["YOUR.IP/32"]`

--- a/envs/us-prod/README.md
+++ b/envs/us-prod/README.md
@@ -1,0 +1,14 @@
+# us-prod — US DR/Active Region
+
+**Status:** Placeholder — Phase 10  
+**Region:** us-west-2 (Oregon)  
+**VPC CIDR:** 10.1.0.0/16 (non-overlapping with AU)  
+
+## How to Create
+
+1. Copy all `.tf` files from `envs/au-prod/`
+2. Update `terraform.tfvars`: region, CIDR, cluster name
+3. Create S3 state bucket in us-west-2
+4. `terraform init && terraform apply`
+
+See `docs/MULTI-REGION-AND-DATA-SOVEREIGNTY.md` for full strategy.

--- a/modules/vpc/c1-versions.tf
+++ b/modules/vpc/c1-versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/vpc/c2-variables.tf
+++ b/modules/vpc/c2-variables.tf
@@ -1,0 +1,77 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+}
+
+variable "common_tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+# Subnet CIDRs - 3 AZs, 3 tiers
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets (ALB, NAT GW) — one per AZ"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "private_app_subnet_cidrs" {
+  description = "CIDR blocks for private app subnets (EKS nodes) — one per AZ"
+  type        = list(string)
+  default     = ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
+}
+
+variable "private_data_subnet_cidrs" {
+  description = "CIDR blocks for private data subnets (RDS, ElastiCache) — one per AZ"
+  type        = list(string)
+  default     = ["10.0.20.0/24", "10.0.21.0/24", "10.0.22.0/24"]
+}
+
+variable "availability_zones" {
+  description = "List of AZs to use — must match subnet count"
+  type        = list(string)
+  default     = ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"]
+}
+
+variable "single_nat_gateway" {
+  description = "Single NAT for dev, one per AZ for prod"
+  type        = bool
+  default     = true
+}
+
+# VPC endpoints - interface ones cost ~$7/mo each
+variable "enable_vpc_endpoints" {
+  description = "Turn on interface VPC endpoints"
+  type        = bool
+  default     = false
+}
+
+variable "enable_endpoint_ssm" {
+  description = "Enable SSM + SSMMessages endpoints for debugging"
+  type        = bool
+  default     = false
+}
+
+variable "enable_flow_logs" {
+  description = "Enable VPC Flow Logs"
+  type        = bool
+  default     = false
+}
+
+variable "flow_logs_retention_days" {
+  description = "Retension days for flow logs in CloudWatch"
+  type        = number
+  default     = 14
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name for subnet tagging"
+  type        = string
+  default     = "ausmart-eks"
+}

--- a/modules/vpc/c3-vpc.tf
+++ b/modules/vpc/c3-vpc.tf
@@ -1,0 +1,150 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-igw"
+  })
+}
+
+# Public subnets - ALB + NAT gateways live here
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-public-${var.availability_zones[count.index]}"
+    "kubernetes.io/role/elb" = "1"  # for AWS LB controller
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-rt-public"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(aws_subnet.public)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# NAT gateway - single for dev, one per AZ for prod
+# TODO: switch to 3 NATs when this goes prod
+resource "aws_eip" "nat" {
+  count  = var.single_nat_gateway ? 1 : length(var.public_subnet_cidrs)
+  domain = "vpc"
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-eip-nat-${count.index}"
+  })
+}
+
+resource "aws_nat_gateway" "main" {
+  count = var.single_nat_gateway ? 1 : length(var.public_subnet_cidrs)
+
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-nat-${count.index}"
+  })
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# Private app subnets - EKS nodes go here
+resource "aws_subnet" "private_app" {
+  count = length(var.private_app_subnet_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_app_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-private-app-${var.availability_zones[count.index]}"
+    "kubernetes.io/role/internal-elb" = "1"
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "karpenter.sh/discovery" = var.cluster_name  # needed for karpenter node discovery
+  })
+}
+
+resource "aws_route_table" "private_app" {
+  count = var.single_nat_gateway ? 1 : length(var.private_app_subnet_cidrs)
+
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[count.index].id
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-rt-private-app-${count.index}"
+  })
+}
+
+resource "aws_route_table_association" "private_app" {
+  count = length(aws_subnet.private_app)
+
+  subnet_id      = aws_subnet.private_app[count.index].id
+  route_table_id = aws_route_table.private_app[var.single_nat_gateway ? 0 : count.index].id
+}
+
+# Private data subnets - RDS, ElastiCache
+resource "aws_subnet" "private_data" {
+  count = length(var.private_data_subnet_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_data_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-private-data-${var.availability_zones[count.index]}"
+  })
+}
+
+resource "aws_route_table" "private_data" {
+  count = var.single_nat_gateway ? 1 : length(var.private_data_subnet_cidrs)
+
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[count.index].id
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-rt-private-data-${count.index}"
+  })
+}
+
+resource "aws_route_table_association" "private_data" {
+  count = length(aws_subnet.private_data)
+
+  subnet_id      = aws_subnet.private_data[count.index].id
+  route_table_id = aws_route_table.private_data[var.single_nat_gateway ? 0 : count.index].id
+}

--- a/modules/vpc/c4-vpc-endpoints.tf
+++ b/modules/vpc/c4-vpc-endpoints.tf
@@ -1,0 +1,102 @@
+data "aws_region" "current" {}
+
+# SG for interface endpoints - only allows HTTPS from within VPC
+resource "aws_security_group" "vpc_endpoints" {
+  count = var.enable_vpc_endpoints ? 1 : 0
+
+  name        = "${var.name_prefix}-sg-vpc-endpoints"
+  description = "Allow HTTPS from VPC CIDR to Interface VPC Endpoints"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTPS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-sg-vpc-endpoints"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Gateway endpoints - these are free, always on
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_endpoint_type = "Gateway"
+
+  route_table_ids = concat(
+    aws_route_table.private_app[*].id,
+    aws_route_table.private_data[*].id
+  )
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-vpce-s3"
+  })
+}
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+
+  route_table_ids = concat(
+    aws_route_table.private_app[*].id,
+    aws_route_table.private_data[*].id
+  )
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-vpce-dynamodb"
+  })
+}
+
+# Interface endpoints - these cost money so they're behind a toggle
+locals {
+  private_subnet_ids = aws_subnet.private_app[*].id
+
+  interface_endpoints = var.enable_vpc_endpoints ? {
+    ecr-api            = "com.amazonaws.${data.aws_region.current.name}.ecr.api"
+    ecr-dkr            = "com.amazonaws.${data.aws_region.current.name}.ecr.dkr"
+    sts                = "com.amazonaws.${data.aws_region.current.name}.sts"
+    secretsmanager     = "com.amazonaws.${data.aws_region.current.name}.secretsmanager"
+    sqs                = "com.amazonaws.${data.aws_region.current.name}.sqs"
+    logs               = "com.amazonaws.${data.aws_region.current.name}.logs"
+  } : {}
+
+  ssm_endpoints = var.enable_vpc_endpoints && var.enable_endpoint_ssm ? {
+    ssm         = "com.amazonaws.${data.aws_region.current.name}.ssm"
+    ssmmessages = "com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+  } : {}
+
+  all_interface_endpoints = merge(local.interface_endpoints, local.ssm_endpoints)
+}
+
+resource "aws_vpc_endpoint" "interface" {
+  for_each = local.all_interface_endpoints
+
+  vpc_id              = aws_vpc.main.id
+  service_name        = each.value
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  subnet_ids         = local.private_subnet_ids
+  security_group_ids = [aws_security_group.vpc_endpoints[0].id]
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-vpce-${each.key}"
+  })
+}

--- a/modules/vpc/c5-flow-logs.tf
+++ b/modules/vpc/c5-flow-logs.tf
@@ -1,0 +1,64 @@
+# Flow logs - off by default, turn on for debugging or compliance
+resource "aws_flow_log" "main" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  vpc_id               = aws_vpc.main.id
+  traffic_type         = "ALL"
+  log_destination_type = "cloud-watch-logs"
+  log_destination      = aws_cloudwatch_log_group.flow_logs[0].arn
+  iam_role_arn         = aws_iam_role.flow_logs[0].arn
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-flow-logs"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name              = "/aws/vpc/flow-logs/${var.name_prefix}"
+  retention_in_days = var.flow_logs_retention_days
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-flow-logs"
+  })
+}
+
+resource "aws_iam_role" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.name_prefix}-vpc-flow-logs"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "vpc-flow-logs.amazonaws.com" }
+    }]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.name_prefix}-vpc-flow-logs"
+  role = aws_iam_role.flow_logs[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ]
+      Resource = "*"
+    }]
+  })
+}

--- a/modules/vpc/c6-outputs.tf
+++ b/modules/vpc/c6-outputs.tf
@@ -1,0 +1,39 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr" {
+  description = "VPC CIDR block"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_app_subnet_ids" {
+  description = "List of private app subnet IDs (EKS nodes)"
+  value       = aws_subnet.private_app[*].id
+}
+
+output "private_data_subnet_ids" {
+  description = "List of private data subnet IDs (RDS, ElastiCache)"
+  value       = aws_subnet.private_data[*].id
+}
+
+output "s3_vpc_endpoint_id" {
+  description = "S3 Gateway VPC endpoint ID"
+  value       = aws_vpc_endpoint.s3.id
+}
+
+output "vpc_endpoint_sg_id" {
+  description = "Security group ID for Interface VPC endpoints"
+  value       = var.enable_vpc_endpoints ? aws_security_group.vpc_endpoints[0].id : null
+}
+
+output "flow_log_id" {
+  description = "VPC Flow Log ID"
+  value       = var.enable_flow_logs ? aws_flow_log.main[0].id : null
+}


### PR DESCRIPTION
## Changes
Restructured Terraform from flat files into reusable modules/ + envs/ pattern.
Created VPC module with 3-AZ support, 3 subnet tiers, VPC endpoints, and flow logs.
Added au-prod and us-prod placeholder folders.

## Why
Flat files can't support multiple environments without code duplication.
With modules/, au-prod is just a new terraform.tfvars — zero code changes.

Closes #26
