### PR TITLE
ALB Ingress

### DIFF
--- a/kubernetes/manifests/07-ingress/ingress-https.yaml
+++ b/kubernetes/manifests/07-ingress/ingress-https.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: retail-ingress-https
+  namespace: retail
+  labels:
+    app: retail
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:REGION:ACCOUNT_ID:certificate/CERTIFICATE_ID"
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": {"Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ui
+                port:
+                  number: 80


### PR DESCRIPTION
HTTP and HTTPS ingress for the retail store. HTTP for testing, HTTPS with ACM cert and ssl-redirect for prod. 


Both use internet-facing ALB with IP mode targeting.

Closes #68
