### PR TITLE
Elasticache module

### DIFF
--- a/modules/elasticache/c1-versions.tf
+++ b/modules/elasticache/c1-versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/elasticache/c2-variables.tf
+++ b/modules/elasticache/c2-variables.tf
@@ -1,0 +1,26 @@
+variable "name_prefix"             { type = string }
+variable "common_tags"             { type = map(string) }
+variable "private_data_subnet_ids" { type = list(string) }
+variable "security_group_id"       { type = string }
+
+variable "node_type" {
+  type    = string
+  default = "cache.t3.micro"
+}
+
+variable "num_cache_nodes" {
+  description = "1 for dev, 2+ for prod"
+  type        = number
+  default     = 1
+}
+
+variable "enable_encryption_at_rest" {
+  type    = bool
+  default = false
+}
+
+variable "enable_encryption_in_transit" {
+  description = "TLS"
+  type        = bool
+  default     = false
+}

--- a/modules/elasticache/c3-redis.tf
+++ b/modules/elasticache/c3-redis.tf
@@ -1,0 +1,30 @@
+# Redis for checkout session store
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.name_prefix}-redis-subnet"
+  subnet_ids = var.private_data_subnet_ids
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name_prefix}-redis-subnet"
+  })
+}
+
+resource "aws_elasticache_cluster" "redis" {
+  cluster_id           = "${var.name_prefix}-redis"
+  engine               = "redis"
+  engine_version       = "7.1"
+  node_type            = var.node_type
+  num_cache_nodes      = var.num_cache_nodes
+  port                 = 6379
+  parameter_group_name = "default.redis7"
+
+  subnet_group_name  = aws_elasticache_subnet_group.main.name
+  security_group_ids = [var.security_group_id]
+
+  at_rest_encryption_enabled = var.enable_encryption_at_rest
+  transit_encryption_enabled = var.enable_encryption_in_transit
+
+  tags = merge(var.common_tags, {
+    Name    = "${var.name_prefix}-redis"
+    Service = "checkout"
+  })
+}

--- a/modules/elasticache/c4-outputs.tf
+++ b/modules/elasticache/c4-outputs.tf
@@ -1,0 +1,8 @@
+output "redis_endpoint" {
+  description = "Redis primary endpoint"
+  value       = aws_elasticache_cluster.redis.cache_nodes[0].address
+}
+
+output "redis_port" {
+  value = aws_elasticache_cluster.redis.port
+}


### PR DESCRIPTION
Redis cluster for Checkout session storage. Single node in dev to keep cost down, replica flag for prod. Subnet group pinned to private data subnets, only EKS nodes SG can reach 6379.

Closes #86
