### PR TITLE
Toggle VPC endpoints per environment

### DIFF
--- a/envs/au-dev/c2-variables.tf
+++ b/envs/au-dev/c2-variables.tf
@@ -67,6 +67,12 @@ variable "enable_vpc_endpoints" {
   default     = false
 }
 
+variable "enable_endpoint_ssm" {
+  description = "SSM + SSMMessages endpoints for node debugging"
+  type        = bool
+  default     = false
+}
+
 variable "enable_flow_logs" {
   description = "Enable VPC flow logs to CloudWatch"
   type        = bool

--- a/envs/au-dev/terraform.tfvars
+++ b/envs/au-dev/terraform.tfvars
@@ -15,8 +15,10 @@ availability_zones        = ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast
 
 single_nat_gateway = true  # saves ~$70/mo vs 3 NATs
 
-# Feature flags - all off for dev to save cost
-enable_vpc_endpoints     = false
+# VPC endpoints - interface ones cost ~$7/mo each (6 endpoints = $44/mo)
+# gateway endpoints (S3, DynamoDB) are always on and free
+enable_vpc_endpoints     = false   # enable in prod
+enable_endpoint_ssm      = false   # SSM for node debugging, enable if needed
 enable_flow_logs         = false
 flow_logs_retention_days = 14
 


### PR DESCRIPTION
Added enable_endpoint_ssm variable for node debugging via SSM. Gateway endpoints (S3, DynamoDB) are always on and free. Interface endpoints toggled off in dev to save $44/month, on in prod.

Closes #88
