### PR TITLE
Restrict EKS endpoint and add WAF toggle

### DIFF
--- a/envs/au-dev/c2-variables.tf
+++ b/envs/au-dev/c2-variables.tf
@@ -138,9 +138,15 @@ variable "public_access_cidrs" {
   default     = ["0.0.0.0/0"]
 }
 
-# KMS
+# Security
 variable "enable_kms" {
   description = "Create customer-managed KMS keys - off for dev, on for prod"
+  type        = bool
+  default     = false
+}
+
+variable "enable_waf" {
+  description = "WAF WebACL - off for dev, on for prod"
   type        = bool
   default     = false
 }

--- a/envs/au-dev/terraform.tfvars
+++ b/envs/au-dev/terraform.tfvars
@@ -31,10 +31,11 @@ node_min_size      = 1
 node_max_size      = 6
 node_desired_size  = 3
 node_disk_size     = 30
-public_access_cidrs = ["0.0.0.0/0"]  # restrict in prod
+public_access_cidrs = ["0.0.0.0/0"]  # prod: ["YOUR.IP/32"]
 
 # Security
-enable_kms = false  # saves ~$3/mo, enable in prod
+enable_kms = false  # ~$3/mo for 3 CMKs
+enable_waf = false  # ~$10/mo for WebACL + managed rules
 
 # Secrets: CSI driver + AWS provider installed via eks-addons module
 # SecretProviderClass manifests come in Phase 3


### PR DESCRIPTION
Added enable_waf variable to au-dev config. Updated tfvars with prod guidance — public_access_cidrs should be locked to specific IP in prod, WAF and KMS costs documented inline.

Closes #90
